### PR TITLE
Make Build.sh change directories

### DIFF
--- a/build OS X.command
+++ b/build OS X.command
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd "$( dirname "$0" )"
+bash autogen.sh
+./configure $*
+make

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$( dirname "$0" )"
 bash autogen.sh
 ./configure $*
 make


### PR DESCRIPTION
Forces Build.sh to run in the directory it is stored in and add a Build script for OS X devices that automatically opens terminal.

Also is this project active?
If not I'd like to take over the project or at least merge it into one that I have started.
